### PR TITLE
Add navigation runtime caching for PWA shell

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -30,7 +30,17 @@ export default defineConfig({
             registerType: 'autoUpdate',
             workbox: {
                 skipWaiting: true,
-                navigateFallbackDenylist: [/^\/attachments*/]
+                navigateFallbackDenylist: [/^\/attachments*/],
+                runtimeCaching: [
+                    {
+                        urlPattern: ({request}) => request.mode === 'navigate',
+                        handler: 'NetworkFirst',
+                        options: {
+                            networkTimeoutSeconds: 3,
+                            cacheName: 'navigation-runtime-cache',
+                        },
+                    },
+                ],
             },
             manifest: {
                 name: "Сборник песен",


### PR DESCRIPTION
## Summary
- add a NetworkFirst runtime caching rule for navigation requests in the PWA configuration
- configure a short network timeout and dedicated cache to improve shell load time when the network is slow

## Testing
- `npm install` *(fails: 403 Forbidden retrieving vuetify package)*
- `npm run build` *(fails: vite not found because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d93d491a3c8332ad4755f03ccb1c32